### PR TITLE
docs: Add GitHub Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,10 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: '[BUG] '
+title: ''
 labels: bug
 assignees: ''
+
 ---
 
 **Describe the bug**
@@ -22,9 +23,16 @@ A clear and concise description of what you expected to happen.
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Environment:**
- - OS: [e.g. macOS, Linux, Windows]
- - Version [e.g. 1.0.0]
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://github.com/Scottcjn/claude-code-power8#readme
+    about: Check the documentation for usage guides and FAQs
+  - name: 💬 Discussions
+    url: https://github.com/Scottcjn/claude-code-power8/discussions
+    about: Ask questions and discuss ideas with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,9 +1,10 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: '[FE '
+title: ''
 labels: enhancement
 assignees: ''
+
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
This PR adds GitHub Issue Templates to help standardize issue reporting and feature requests.

## Changes
- Added bug report template ()
- Added feature request template ()
- Added template configuration ()

Closes #6