### PR TITLE
[codex] Add Dependabot for package and workflow updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/claude-code"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` for the nested `claude-code` npm package.
- Add weekly GitHub Actions update checks for the existing CI workflow.
- Keep the config scoped to the dependency surfaces present in this repo: `/claude-code` npm metadata and root workflows.

## Bounty

Refs Scottcjn/rustchain-bounties#1613.

## Validation

- Confirmed `.github/dependabot.yml` was absent before this change.
- Confirmed no open PRs existed in this repo immediately before opening this PR.
- Parsed the new YAML with Ruby/Psych.
- Ran `git diff --cached --check` before commit.
