### PR TITLE
chore: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Add Dependabot updates for the existing GitHub Actions workflow.
- Keeps workflow actions current on a weekly schedule.

## Test plan
- Configuration-only change; verified the repo has `.github/workflows/ci.yml` using GitHub Actions.

Bounty: Scottcjn/rustchain-bounties#1613