### PR TITLE
Fix RustChain branding in README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ https://github.com/Scottcjn/claude-code-power8
 
 <div align="center">
 
-**[Elyan Labs](https://github.com/Scottcjn)** · [⭐ Star Rustchain](https://github.com/Scottcjn/Rustchain) · [Follow @Scottcjn](https://github.com/Scottcjn)
+**[Elyan Labs](https://github.com/Scottcjn)** · [⭐ Star RustChain](https://github.com/Scottcjn/Rustchain) · [Follow @Scottcjn](https://github.com/Scottcjn)
 
 </div>
 


### PR DESCRIPTION
## Summary
- update the README footer link text from `Star Rustchain` to `Star RustChain`

## Validation
- `git diff --check`
- duplicate check: open PR list only showed unrelated Dependabot PRs #27/#28
- duplicate check: open branding/capitalization PR search returned no hits
- duplicate check: rustchain-bounties #2178 comments had no claude-code-power8 submission before this PR